### PR TITLE
Set buildpack: binary_buildpack

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,6 +1,6 @@
 applications:
   - name: cf-quick-app-rc
     memory: 16M
-    disk_quota: 64M
+    disk_quota: 32M
     timeout: 180
     health-check-type: process

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,7 +1,7 @@
 applications:
-  - name: cf-quick-app-rc
+  - name: cf-quick-app
     memory: 16M
-    disk_quota: 32M
+    disk_quota: 64M
     timeout: 180
     health-check-type: process
     buildpack: binary_buildpack

--- a/manifest.yml
+++ b/manifest.yml
@@ -4,3 +4,4 @@ applications:
     disk_quota: 32M
     timeout: 180
     health-check-type: process
+    buildpack: binary_buildpack

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,5 +1,5 @@
 applications:
-  - name: cf-quick-app
+  - name: cf-quick-app-rc
     memory: 16M
     disk_quota: 64M
     timeout: 180


### PR DESCRIPTION
On PCF it fails to push due to inability to determine buildpack type. Not urgent (noticed whilst testing new e2e deploy test, not really needed, also added a tweak to allow repo name from config)!
